### PR TITLE
Use new JS Solr Utils library

### DIFF
--- a/app/assets/stylesheets/places_engine/related.css
+++ b/app/assets/stylesheets/places_engine/related.css
@@ -1,0 +1,31 @@
+.collapsibleList li{
+  cursor: auto;
+}
+li.collapsibleListOpen,li.collapsibleListClosed, .collapsible_all_btn{
+  cursor: pointer;
+}
+.collapsible_all_btn{
+  color: #454fa4;
+}
+.collapsible_all_btn:hover,.collapsible_all_btn_selected{
+  color: #df3d26;
+}
+li.collapsibleListOpen .glyphicon:before{
+  content: "\e082";
+}
+li.collapsibleListClosed .glyphicon:before{
+  content: "\e081";
+}
+li.collapsibleListOpen:before, li.collapsibleListClosed:before{
+  display:none !important;
+}
+.collapsibleList span.glyphicon {
+  padding-right: 5px;
+  color: #4ca6fb !important;
+}
+#relation_details .tab-content-loading{
+  position:relative;
+  top:0;
+  right:0;
+  background-image: none;
+}

--- a/app/views/admin/features/select_ancestor.html.erb
+++ b/app/views/admin/features/select_ancestor.html.erb
@@ -3,9 +3,9 @@
 </div>
 <div id="relation_tree_container">
 </div>
-<%= javascript_include_tag 'kmaps_engine/kmaps_fancytree' %>
+<%= javascript_include_tag 'kmaps_engine/kmaps_relations_tree' %>
 <%= javascript_on_load do %>
-  $("#relation_tree_container").kmapsFancytree({
+  $("#relation_tree_container").kmapsRelationsTree({
     featureId: "13735",
     featuresPath: "<%= new_admin_feature_path %>?parent_id=%%ID%%",
     termIndex: "<%= Feature.config.url %>",

--- a/app/views/features/_related.html.erb
+++ b/app/views/features/_related.html.erb
@@ -1,36 +1,4 @@
 <% feature_label = fname_labels(@feature).s %>
-<%= javascript_on_load do %>
-  //Related Counts on Solr
-  var termIndex = "<%= Feature.config.url %>";
-  var assetIndex = "<%= Flare.config.asset_url %>";
-  var count = 0;
-  var key =  "<%= @feature.uid %>";
-  var relatedCountsUrl =
-  termIndex + '/select?q={!child of=block_type:parent}id:' + key + '&wt=json&indent=true&group=true&group.field=block_child_type&group.limit=0&wt=json&json.wrf=?';
-  $.ajax({
-    type: "GET",
-    url: relatedCountsUrl,
-    dataType: "jsonp",
-    timeout: 90000,
-    error: function (e) {
-      console.error(e);
-    },
-    beforeSend: function () {
-    },
-    success: function (data) {
-      var updates = {};
-      $.each(data.grouped.block_child_type.groups, function (x, y) {
-      var block_child_type = y.groupValue;
-      var rel_count = y.doclist.numFound;
-      updates[block_child_type] = rel_count;
-      });
-      count = updates;
-      $(".relatedCountContainer").each(function(){
-          $(this).html(count["related_<%= Feature.uid_prefix %>"]);
-      });
-    }
-  });
-<% end %>
 <div id='myTabs'>
   <!-- Nav tabs -->
   <ul class="nav nav-tabs" role="tablist">
@@ -70,8 +38,22 @@
 	</div> <!-- Tab Panes end -->
 </div> <!-- myTabs end -->
 
-<%= javascript_include_tag 'kmaps_engine/kmaps_fancytree' %>
+<%= javascript_include_tag 'kmaps_engine/kmaps_relations_tree' %>
 <%= javascript_on_load do %>
+  var relatedSolrUtils = kmapsSolrUtils.init({
+    termIndex: "<%= Feature.config.url %>",
+    assetIndex: "<%= Flare.config.asset_url %>",
+    featureId:  "<%= Feature.uid_prefix %>-<%= @feature.fid %>",
+    domain: "<%= Feature.uid_prefix %>",
+    perspective: "<%= current_perspective.code %>",
+  });
+  //Related Counts on Solr
+  relatedSolrUtils.getDirectDescendatCount().then(function(count){
+      $(".relatedCountContainer").each(function(){
+          $(this).html(count);
+      });
+  });
+
   var summaryLoaded = false;
   var collapsibleApplied = false;
   var popupsSet = false;
@@ -79,119 +61,14 @@
   $('#summary-tab-link[data-toggle="tab"]').on('shown.bs.tab', function (e) {
   //Code for Summary
   if(!summaryLoaded){
-    var termIndex = "<%= Feature.config.url %>";
-    var assetIndex = "<%= Flare.config.asset_url %>";
-    var domain = "<%= Feature.uid_prefix %>";
-    var perspective = "<%= current_perspective.code %>";
-    var SOLR_ROW_LIMIT = 200;
-    var count = 0;
-    var featureId =  "<%= @feature.uid %>";
-    var featuresPath = "<%= features_path %>/%%ID%%";
-    var fieldList = [
-      "header",
-      "id",
-      "ancestor*",
-      "caption_eng",
-      "related_"+domain+"_feature_type_s",
-      "related_"+domain+"_relation_label_s"
-    ].join(",");
-    if(domain == "places"){
-      fieldList += ",related_subjects_t";
-    }
-    var url = termIndex + "/select?" +
-    "&q=" + "{!child of=block_type:parent}id:" + featureId +
-    "&fl=related*,related_"+domain+"_feature_types_t,uid,related_"+domain+"_id_s,related_"+domain+"_header_s" +","+ fieldList +
-    "&rows=" + SOLR_ROW_LIMIT +
-    "&indent=true" +
-    "&wt=json" +
-    "&json.wrf=?" +
-    "&sort=related_"+domain+"_header_s+asc";
-    $.ajax({
-      url: url,
-      dataType: 'jsonp',
-      jsonp: 'json.wrf',
-      beforeSend: function(){
-        $("#relation_details .tab-content-loading").show();
-      }
-    }).done(function(data){
-      var response = data.response;
-      if(response.numFound > 0){
-        var result = response.docs.reduce(function(acc,currentNode,index){
-          var node_type = currentNode["related_kmaps_node_type"] ;
-          if(node_type === undefined) {
-            node_type = "other";
-          }
-          if(acc[node_type] === undefined){
-            acc[node_type] =  [];
-          }
-          var relation_label = currentNode["related_"+ domain +"_relation_label_s"];
-          if(acc[node_type][relation_label] === undefined){
-            acc[node_type][relation_label] = [];
-          }
-          for(related_feature_type_key in currentNode["related_"+domain+"_feature_types_t"]){
-            var related_feature_type = currentNode["related_"+domain+"_feature_types_t"][related_feature_type_key];
-            if(acc[node_type][relation_label][related_feature_type] === undefined) {
-              acc[node_type][relation_label][related_feature_type] = {};
-            }
-            var node_id = currentNode['related_'+domain+'_id_s'];
-            acc[node_type][relation_label][related_feature_type][node_id] = currentNode;
-          }
-          return acc;
-        }, []);
-        var feature_name = $('<%= feature_label %>')[0];
-        function addSummaryItems(group_key,data,container){
-          for(var key in data[group_key]){ //parent,child, other
-            var feature_block = jQuery('<div></div>').addClass('feature-block');
-            var header = jQuery('<h6></h6>').html(feature_name.innerText +" "+ key);
-            feature_block.append(header);
-            var relation_subject_list = jQuery('<ul class="collapsibleList"></ul>');
-            var relation_subjects_ordered = Object.keys(data[group_key][key]).sort();
-            for(var relation_subject in relation_subjects_ordered){
-              relation_subject = relation_subjects_ordered[relation_subject];
-              var relation = jQuery('<li></li>');
-              var feature_list = jQuery('<ul></ul>');
-              var feature_count = 0;
-              var sortedFeatures = data[group_key][key][relation_subject];
-              for(var feature_index in sortedFeatures){
-                var feature_item = jQuery('<li></li>');
-                var currNode = sortedFeatures[feature_index];
-                var currNodeID = currNode["related_"+domain+"_id_s"].replace(domain+"-","");
-                var currItem = jQuery("<a href="+featuresPath.replace("%%ID%%",currNodeID)+">"+currNode["related_"+domain+"_header_s"]+"</a>");
-                var pop_container = jQuery('<span class="popover-kmaps" data-id="'+domain+'-'+currNodeID+'"><span class="popover-kmaps-tip"></span><span class="icon shanticon-menu3"></span></span>');
-                feature_item.append(currItem);
-                feature_item.append(jQuery(pop_container));
-                feature_list.append(feature_item);
-                feature_count++;
-              }
-              relation.append(jQuery('<span class="glyphicon"></span> '));
-              relation.append(relation_subject+" ("+feature_count+")");
-              relation.append(feature_list);
-              relation_subject_list.append(relation);
-            }
-            feature_block.append(relation_subject_list);
-            container.append(feature_block);
-          }
-        }
-        function featureSort(features){
-          var featuresArr = [];
-          for(var key in features){
-              var index = 0;
-              while(index < featuresArr.length){
-                var curr_feature = featuresArr[index];
-                if(features[key]["related_"+domain+"_header_s"] < curr_feature["related_"+domain+"_header_s"] )
-                  break;
-                index++;
-              }
-              featuresArr.splice(index,0,features[key]);
-          }
-          return featuresArr;
-        }
-        addSummaryItems('parent',result,jQuery('.'+domain+'-in-'+domain));
-        addSummaryItems('child',result,jQuery('.'+domain+'-in-'+domain));
-        //addSummaryItems('other',result,jQuery('.'+domain+'-in-'+domain));
-      } else {
-       //Empty result set
-      }
+    $("#relation_details .tab-content-loading").show();
+    relatedSolrUtils.getPlacesSummaryElements().then(function(result){
+      var feature_label = $('<%= feature_label %>')[0].innerText;
+      var feature_path = "<%= features_path %>/%%ID%%";
+      relatedSolrUtils.addPlacesSummaryItems(feature_label,feature_path,'parent',result);
+      relatedSolrUtils.addPlacesSummaryItems(feature_label,feature_path,'child',result);
+      //relatedSolrUtils.addPlacesSummaryItems(feature_label,feature_path,'other',result);
+
       // Functionality for columnizer
       // dontsplit = don't break these headers
       $('.places-in-places').find('.column > h6, .column > ul > li, .column ul').addClass("dontsplit");
@@ -212,12 +89,11 @@
       }
       if(!popupsSet){
         jQuery('#relation_details .popover-kmaps').kmapsPopup({
-          termIndex: "<%= Feature.config.url %>",
-          assetIndex: "<%= Flare.config.asset_url %>",
+          featuresPath: "<%= features_path %>/%%ID%%",
           domain: "<%= Feature.uid_prefix %>",
-          perspective: "<%= current_perspective.code %>",
           featureId:  "",
-          featuresPath: "<%= features_path %>/%%ID%%"
+          mandalaURL: "https://mandala.shanti.virginia.edu/%%APP%%/%%ID%%/%%REL%%/nojs",
+          solrUtils: relatedSolrUtils
         });
         popupsSet = true;
        }
@@ -225,9 +101,9 @@
       $("#relation_details .collapsible_btns_container").show();
       summaryLoaded = true;
     });
-   }
-  });
-  // END - Functionality for columnizer
+  }
+  }); // END - Summary Tab on show action
+
   $(".collapsible_expand_all").on("click",function(e){
    $(".collapsible_collapse_all").removeClass("collapsible_all_btn_selected");
     if (!$(".collapsible_expand_all").hasClass("collapsible_all_btn_selected")) {
@@ -242,7 +118,7 @@
     }
     $('.collapsibleList').kmapsCollapsibleList('collapseAll');
   });
-  $("#relation_tree_container").kmapsFancytree({
+  $("#relation_tree_container").kmapsRelationsTree({
     featureId: "<%= @feature.fid %>",
     termIndex: "<%= Feature.config.url %>",
     assetIndex: "<%= Flare.config.asset_url %>",
@@ -256,37 +132,5 @@
     displayPopup: true
   });
 <% end %>
-<style>
-.collapsibleList li{
-  cursor: auto;
-}
-li.collapsibleListOpen,li.collapsibleListClosed, .collapsible_all_btn{
-  cursor: pointer;
-}
-.collapsible_all_btn{
-  color: #454fa4;
-}
-.collapsible_all_btn:hover,.collapsible_all_btn_selected{
-  color: #df3d26;
-}
-li.collapsibleListOpen .glyphicon:before{
-  content: "\e082";
-}
-li.collapsibleListClosed .glyphicon:before{
-  content: "\e081";
-}
-li.collapsibleListOpen:before, li.collapsibleListClosed:before{
-  display:none !important;
-}
-.collapsibleList span.glyphicon {
-  padding-right: 5px;
-  color: #4ca6fb !important;
-}
-#relation_details .tab-content-loading{
-  position:relative;
-  top:0;
-  right:0;
-  background-image: none;
-}
-</style>
-<%= javascript_include_tag('collapsible_list/jquery.collapsibleList') %>
+<%= stylesheet_link_tag('places_engine/related') %>
+<%= javascript_include_tag('collapsible_list/jquery.kmapsCollapsibleList') %>

--- a/app/views/features/_related.html.erb
+++ b/app/views/features/_related.html.erb
@@ -1,3 +1,4 @@
+<%= stylesheet_link_tag('places_engine/related') %>
 <% feature_label = fname_labels(@feature).s %>
 <div id='myTabs'>
   <!-- Nav tabs -->
@@ -132,5 +133,4 @@
     displayPopup: true
   });
 <% end %>
-<%= stylesheet_link_tag('places_engine/related') %>
 <%= javascript_include_tag('collapsible_list/jquery.kmapsCollapsibleList') %>

--- a/lib/places_engine/engine.rb
+++ b/lib/places_engine/engine.rb
@@ -1,8 +1,8 @@
 module PlacesEngine
   class Engine < ::Rails::Engine
     initializer :assets do |config|
-      Rails.application.config.assets.precompile.concat(['places_engine/inset-map.js', 'places_engine/top.js', 'places_engine/THLWMS.js'])
-      Rails.application.config.assets.precompile.concat(['places_engine/related.css'])
+      Rails.application.config.assets.precompile.concat(['places_engine/inset-map.js', 'places_engine/top.js', 'places_engine/THLWMS.js',
+        'places_engine/related.css'])
     end
         
     initializer :loader do |config|

--- a/lib/places_engine/engine.rb
+++ b/lib/places_engine/engine.rb
@@ -2,6 +2,7 @@ module PlacesEngine
   class Engine < ::Rails::Engine
     initializer :assets do |config|
       Rails.application.config.assets.precompile.concat(['places_engine/inset-map.js', 'places_engine/top.js', 'places_engine/THLWMS.js'])
+      Rails.application.config.assets.precompile.concat(['places_engine/related.css'])
     end
         
     initializer :loader do |config|


### PR DESCRIPTION
The code has been updated to use the new JS Solr Utils library that
reduces the code and makes the partial be cleaner.

This commit has the following changes:

Update code related to Kmaps jQuery Plugins
Updated the code to reflect changes on the Kmaps jQuery plugins
Relations Tree and Collapsible List

Update KmapsPopup to use solr-utils library
Updated the code from jquery.kmaps-popup.js to now use the solr-utils.js
library this to keep all the solr queries in one place and simplify the
code. So the code in the _related plartial was updated to reflect this
change.

Update code to on related for summary
Cleaned code for new update on solr-utils library