### PR TITLE
Use new relations tree plugin and URL pattern

### DIFF
--- a/app/views/features/_menu.html.erb
+++ b/app/views/features/_menu.html.erb
@@ -90,7 +90,7 @@
     domain: "<%= Feature.uid_prefix %>",//"places",
     filters_domain: 'subjects',
     root_kmap_path: null,
-    features_path: "<%= (defined?(admin) && admin) ? admin_features_path : features_path %>/",
+    features_path: "<%= (defined?(admin) && admin) ? admin_features_path : features_path %>/%%ID%%",
   });
 <% end %>
   </section>

--- a/app/views/features/_related.html.erb
+++ b/app/views/features/_related.html.erb
@@ -1,5 +1,5 @@
 <%= stylesheet_link_tag('places_engine/related') %>
-<% feature_label = fname_labels(@feature).s %>
+<%  feature_label = fname_labels(@feature).s %>
 <div id='myTabs'>
   <!-- Nav tabs -->
   <ul class="nav nav-tabs" role="tablist">


### PR DESCRIPTION
The code has been updated to use the new plugin kmaps_relations_tree,
just the name changed and now it supports the use of a pattern in the
URL to replace de %%ID%% in the pattern with the specif node fid.