### PR TITLE
Fix Category display in feature_object_type show partial

### DIFF
--- a/app/views/admin/feature_object_types/show.html.erb
+++ b/app/views/admin/feature_object_types/show.html.erb
@@ -24,7 +24,7 @@
   </div>
   <div class="row">
     <label><%= FeatureObjectType.model_name.human.titleize.s %></label>
-    <span><%= def_if_blank object, :category, :title %></span>
+    <span><%= def_if_blank object, :category, :header %></span>
   </div>
 </fieldset>
     </div> <!-- END panel-body -->

--- a/lib/places_engine/version.rb
+++ b/lib/places_engine/version.rb
@@ -1,3 +1,3 @@
 module PlacesEngine
-  VERSION = '4.8.9'
+  VERSION = '4.9.0'
 end


### PR DESCRIPTION
The partial was expecting category to have a field name title, but the
correct field should be header, this has been fixed.