### PR TITLE
Fix bug on Subject creation - MANU-5135

### DIFF
--- a/app/controllers/admin/category_features_controller.rb
+++ b/app/controllers/admin/category_features_controller.rb
@@ -7,13 +7,12 @@ class Admin::CategoryFeaturesController < AclController
   def create
     mca_hash = params[:category_feature]
     mca_cats = mca_hash[:category_id]
-    errors = []
     @feature = Feature.find(params[:feature_id])
     if mca_cats.nil?
       redirect_to admin_feature_url(@feature.fid)
     elsif mca_cats.size==1
       mca_hash[:category_id] = mca_cats.first
-      @cf = @feature.category_features.new(mca_hash)
+      @cf = @feature.category_features.new(mca_hash.permit(:category_id, :string_value, :numeric_value, :show_parent, :show_root, :label, :prefix_label))
       respond_to do |format|
         if @cf.save
           format.html { redirect_to admin_feature_url(@feature.fid) }
@@ -41,6 +40,11 @@ class Admin::CategoryFeaturesController < AclController
   end
   
   private
+  
+  def category_feature_params
+    binding.pry
+    params.permit(:category_id)
+  end
   
   def build_object
     if object_params.nil?

--- a/app/controllers/admin/category_features_controller.rb
+++ b/app/controllers/admin/category_features_controller.rb
@@ -36,7 +36,7 @@ class Admin::CategoryFeaturesController < AclController
   
   # Only allow a trusted parameter "white list" through.
   def category_feature_params
-    params.require(:category_feature).permit(:prefix_label, :label, :string_value, :numeric_value, :show_parent, :category_id, :show_root, :skip_update)
+    params.require(:category_feature).permit(:prefix_label, :label, :string_value, :numeric_value, :show_parent, :category_id, :show_root)
   end
   
   private

--- a/app/controllers/admin/category_features_controller.rb
+++ b/app/controllers/admin/category_features_controller.rb
@@ -42,7 +42,6 @@ class Admin::CategoryFeaturesController < AclController
   private
   
   def category_feature_params
-    binding.pry
     params.permit(:category_id)
   end
   

--- a/app/controllers/admin/category_features_controller.rb
+++ b/app/controllers/admin/category_features_controller.rb
@@ -41,10 +41,6 @@ class Admin::CategoryFeaturesController < AclController
   
   private
   
-  def category_feature_params
-    params.permit(:category_id)
-  end
-  
   def build_object
     if object_params.nil?
       @object ||= end_of_association_chain.send :build

--- a/app/controllers/admin/category_features_controller.rb
+++ b/app/controllers/admin/category_features_controller.rb
@@ -12,7 +12,7 @@ class Admin::CategoryFeaturesController < AclController
       redirect_to admin_feature_url(@feature.fid)
     elsif mca_cats.size==1
       mca_hash[:category_id] = mca_cats.first
-      @cf = @feature.category_features.new(mca_hash.permit(:category_id, :string_value, :numeric_value, :show_parent, :show_root, :label, :prefix_label))
+      @cf = @feature.category_features.new(mca_hash.permit(:prefix_label, :label, :string_value, :numeric_value, :show_parent, :category_id, :show_root))
       respond_to do |format|
         if @cf.save
           format.html { redirect_to admin_feature_url(@feature.fid) }

--- a/app/models/category_feature.rb
+++ b/app/models/category_feature.rb
@@ -93,7 +93,7 @@ class CategoryFeature < ActiveRecord::Base
   
   def self.delete_cumulative_information(category, feature_id)
     while !category.nil? && CumulativeCategoryFeatureAssociation.where(:category_id => category.children.collect(&:id), :feature_id => feature_id).count==0
-      CumulativeCategoryFeatureAssociation.delete_all(:category_id => category.id.to_i, :feature_id => feature_id)
+      CumulativeCategoryFeatureAssociation.where(:category_id => category.id.to_i, :feature_id => feature_id).delete_all
       CachedCategoryCount.updated_count(category.id.to_i, true)
       category = category.parent
     end


### PR DESCRIPTION
When creating a new Subject associated to a Place, which is represented
by a CategoryFeature, the user got an error.

The code used to only send a hash with all the parameters, which is not
allowed any more since Rails 5.1, I just authorized the current
allowed parameters.