### PR TITLE
Fixes problem when redirecting stdout on importation script - MANU-5393

### DIFF
--- a/lib/places_engine/import/feature_importation.rb
+++ b/lib/places_engine/import/feature_importation.rb
@@ -98,6 +98,7 @@ module PlacesEngine
               else
                 puts "#{Time.now}: #{self.feature.pid}: the following fields have been ignored: #{self.fields.keys.join(', ')}"
               end
+              STDOUT.flush
             end
           rescue Exception => e
             log.fatal { "#{Time.now}: An error occured when processing #{Process.pid}:" }

--- a/lib/places_engine/import/feature_importation.rb
+++ b/lib/places_engine/import/feature_importation.rb
@@ -76,6 +76,7 @@ module PlacesEngine
             for i in current...limit
               row = rows[i]
               self.fields = row.to_hash.delete_if{ |key, value| value.blank? }
+              self.fields.each_value(&:strip!)
               next unless self.get_feature(i+1)
               self.process_feature
               self.process_names(44)


### PR DESCRIPTION
**Jira Issue:** MANU-5393

**Changes proposed in this pull request:**

 + fixes the problem when running the script and redirecting the output will not capture any text from the forks created by the script.

**Details of the implementation:**
Did a STDOUT.flush at the end of every fork, so anything that was left
on the stdout buffer will be printed on screen and then be able to
capture it when using redirect.