### PR TITLE
Using the new popovers on the flyout search results - MANU-5491

### DIFF
--- a/app/assets/javascripts/places_engine/related-section-initializer.js
+++ b/app/assets/javascripts/places_engine/related-section-initializer.js
@@ -17,7 +17,7 @@ $(function() {
     $("#relation_details .tab-content-loading").show();
     relatedSolrUtils.getPlacesSummaryElements().then(function(result){
       var feature_label = $($('#related_js_data').data('featureLabel'))[0].innerText;
-      var feature_path = $('#related_js_data').data('featurePath');
+      var feature_path = $('#related_js_data').data('featuresPath');
       relatedSolrUtils.addPlacesSummaryItems(feature_label,feature_path,'parent',result);
       relatedSolrUtils.addPlacesSummaryItems(feature_label,feature_path,'child',result);
       //relatedSolrUtils.addPlacesSummaryItems(feature_label,feature_path,'other',result);
@@ -42,11 +42,12 @@ $(function() {
       }
       if(!popupsSet){
         jQuery('#relation_details .popover-kmaps').kmapsPopup({
-          featuresPath: $('#related_js_data').data('featurePath'),
+          featuresPath: $('#related_js_data').data('featuresPath'),
           domain: $('#related_js_data').data('domain'),
           featureId:  "",
           mandalaURL: $('#related_js_data').data('mandalaPath'),
-          solrUtils: relatedSolrUtils
+          solrUtils: relatedSolrUtils,
+          language: $('#related_js_data').data('language'),
         });
         popupsSet = true;
        }
@@ -83,11 +84,13 @@ $(function() {
     perspective: $('#related_js_data').data('perspective'),
     tree: $('#related_js_data').data('tree'), //places
     domain: $('#related_js_data').data('domain'), //places
-    seedTree: {
-      descendants: true,
-      directAncestors: false,
-    },
+    descendants: true,
+    directAncestors: true,
+    descendantsFullDetail: true,
+    sortBy: "related_"+$('#related_js_data').data('domain')+"_header_s+ASC",
     displayPopup: true,
-    solrUtils: relatedSolrUtils
+    solrUtils: relatedSolrUtils,
+    language: $('#related_js_data').data('language'),
+    featuresPath: $('#menu_js_data').data('featuresPath'),
   });
 });

--- a/app/views/features/_menu.html.erb
+++ b/app/views/features/_menu.html.erb
@@ -80,19 +80,6 @@
       </div>
 	</section>
 <%  end %>
-<%= javascript_on_load do %>
-  $("#kmaps-explorer-search-term").focusin(function(){
-   $(".view-section .nav.nav-tabs a[href='.listview']").tab("show");
-  });
-  $("#kmaps-explorer-search-term").flyoutKmapsTypeahead({
-    hostname: "<%= Feature.config.url %>",
-    hostname_assets: "<%= Flare.config.asset_url %>",
-    domain: "<%= Feature.uid_prefix %>",//"places",
-    filters_domain: 'subjects',
-    root_kmap_path: null,
-    features_path: "<%= (defined?(admin) && admin) ? admin_features_path : features_path %>/%%ID%%",
-  });
-<% end %>
   </section>
   <!-- END input section -->
   <!-- BEGIN view section -->
@@ -113,29 +100,71 @@
 	  </div>
   </section>
 </section>
-<% feature = contextual_feature %>
-    <script type='text/javascript'>
-$(document).ready(function(){
-        $("#tree").kmapsTree({
-          termindex_root: "<%= Feature.config.url %>",
-          kmindex_root: "<%= MmsIntegration::Picture.config.url %>",
-          type: "<%= Feature.uid_prefix %>", //places
-          root_kmap_path: '',
-          //baseUrl: "<%= features_path %>",
-          baseUrl: "<%= (defined?(admin) && admin) ? admin_features_path : features_path %>/%%ID%%",
-          expand_path: "",
-          perspective: "<%= current_perspective.code %>",
-          view: "<%= current_view.code %>",
-<%        unless feature.nil? %>
-          activeNodeId: "<%= feature.fid %>",
-<%        end %>
-        });
-});
-    </script>
+<% feature = contextual_feature
+   fid = feature.nil? ? nil : feature.fid
+   uid = !fid.nil? ? "#{Feature.uid_prefix}-#{fid}" : "";
+%>
+<%= content_tag :div, "", id: 'menu_js_data', data: {
+ term_index: Feature.config.url,
+ asset_index: Flare.config.asset_url,
+ feature_id: uid,
+ domain: Feature.uid_prefix,
+ perspective: current_perspective.code,
+ tree: Feature.uid_prefix,
+ features_path: "#{(defined?(admin) && admin) ? admin_features_path : features_path}/%%ID%%",
+ mandala_path: "https://mandala.shanti.virginia.edu/%%APP%%/%%ID%%/%%REL%%/nojs",
+ feature_fid: uid,
+ language: Language.current.code,
+ view: current_view.code,
+ activeNodeId: fid,
+} %>
+<%= javascript_include_tag 'kmaps_engine/kmaps_relations_tree' %>
 <%= javascript_on_load do %>
-      var session_search = Cookies.getJSON('search_<%= Feature.uid_prefix %>');
-      if(session_search) {
-        $("#kmaps-explorer-search-term").flyoutKmapsTypeahead('restoreSavedSearch', session_search,'kmaps-explorer');
-				Cookies.remove('search_<%= Feature.uid_prefix %>');
-      }
+  var menuSolrUtils = kmapsSolrUtils.init({
+    termIndex: $('#menu_js_data').data('termIndex'),
+    assetIndex: $('#menu_js_data').data('assetIndex'),
+    featureId: $('#menu_js_data').data('featureId'),
+    domain: $('#menu_js_data').data('domain'),
+    perspective: $('#menu_js_data').data('perspective'),
+    tree: $('#menu_js_data').data('tree'), //places
+    featuresPath: $('#menu_js_data').data('featuresPath'),
+  });
+
+  $("#kmaps-explorer-search-term").focusin(function(){
+   $(".view-section .nav.nav-tabs a[href='.listview']").tab("show");
+  });
+
+  $("#kmaps-explorer-search-term").flyoutKmapsTypeahead({
+    hostname: $('#menu_js_data').data('termIndex'),
+    hostname_assets: $('#menu_js_data').data('assetIndex'),
+    domain: $('#menu_js_data').data('domain'),
+    filters_domain: 'subjects',
+    root_kmap_path: null,
+    features_path: "<%= (defined?(admin) && admin) ? admin_features_path : features_path %>/%%ID%%",
+    solrUtils: menuSolrUtils,
+    language: $('#menu_js_data').data('language'),
+  });
+
+  $("#tree").kmapsRelationsTree({
+    featureId: $('#menu_js_data').data('featureFid'),
+    termIndex: $('#menu_js_data').data('termIndex'),
+    assetIndex: $('#menu_js_data').data('assetIndex'),
+    perspective: $('#menu_js_data').data('perspective'),
+    tree: $('#menu_js_data').data('tree'), //places
+    domain: $('#menu_js_data').data('domain'), //places
+    descendants: true,
+    directAncestors: false,
+    descendantsFullDetail: false,
+    initialScrollToActive: true,
+    displayPopup: true,
+    solrUtils:  menuSolrUtils,
+    language: $('#menu_js_data').data('language'),
+    featuresPath: $('#menu_js_data').data('featuresPath'),
+  });
+
+  var session_search = Cookies.getJSON('search_<%= Feature.uid_prefix %>');
+  if(session_search) {
+  $("#kmaps-explorer-search-term").flyoutKmapsTypeahead('restoreSavedSearch', session_search,'kmaps-explorer');
+  Cookies.remove('search_<%= Feature.uid_prefix %>');
+  }
 <% end %>

--- a/app/views/features/_related.html.erb
+++ b/app/views/features/_related.html.erb
@@ -42,7 +42,6 @@
 		</div>
 	</div> <!-- Tab Panes end -->
 </div> <!-- myTabs end -->
-
 <%= content_tag :div, "", id: 'related_js_data', data: {
  term_index: Feature.config.url,
  asset_index: Flare.config.asset_url,
@@ -51,9 +50,10 @@
  perspective: current_perspective.code,
  tree: Feature.uid_prefix,
  feature_label: feature_label,
- feature_path: "#{features_path}/%%ID%%",
+ features_path: "#{features_path}/%%ID%%",
  mandala_path: "https://mandala.shanti.virginia.edu/%%APP%%/%%ID%%/%%REL%%/nojs",
- feature_fid: @feature.fid
+ feature_fid: @feature.fid,
+ language: Language.current.code
 } %>
 <%= javascript_include_tag 'kmaps_engine/kmaps_relations_tree' %>
 <%= javascript_include_tag 'places_engine/related-section-initializer' %>

--- a/config/locales/bo/views.yml
+++ b/config/locales/bo/views.yml
@@ -1,7 +1,7 @@
 # Places engine view localization file for Tibetan.
 bo:
     app:
-        short: 'THLས་མིང་གི་ཚིག་མཛོད།'
+        short: 'ས་མིང་གི་ཚིག་མཛོད།'
         this: 'བོད་དང་ཧི་མ་ལ་ཡའི་རྒྱུད་ཀྱི་ས་མིང་གི་ཚིག་མཛོད།'
     entry: 'ས་མིང་ཚིག་མཛོད་ཀྱི་ས་བཅད།'
     feature:

--- a/config/locales/dz/views.yml
+++ b/config/locales/dz/views.yml
@@ -1,9 +1,9 @@
 # Places engine view localization file for Dzongkha.
 dz:
     app:
-        short: 'THL Place Dictionary'
-        this: 'THL Place Dictionary of Tibet & the Himalayas'
-    entry: 'THL Place Dictionary Entry'
+        short: 'Places'
+        this: 'Places Dictionary'
+    entry: 'Places Entry'
     feature:
         detail:
             one: 'Feature Detail'

--- a/config/locales/en/views.yml
+++ b/config/locales/en/views.yml
@@ -2,7 +2,7 @@
 en:
     app:
         short: 'Places'
-        this: 'Place Dictionary'
+        this: 'Places Dictionary'
     entry: 'Places Entry'
     feature:
         detail:

--- a/config/locales/zh/views.yml
+++ b/config/locales/zh/views.yml
@@ -1,9 +1,9 @@
 # Places engine view localization file for Chinese.
 zh:
     app:
-        short: 'THL地名词典'
-        this: '西藏和喜马拉雅地区THL地名词典'
-    entry: 'THL地名词典词条'
+        short: '地名词典'
+        this: '西藏和喜马拉雅地区地名词典'
+    entry: '地名词典词条'
     feature:
         detail:
             one: '特征细节'

--- a/lib/places_engine/version.rb
+++ b/lib/places_engine/version.rb
@@ -1,3 +1,3 @@
 module PlacesEngine
-  VERSION = '5.0.4'
+  VERSION = '5.0.5'
 end


### PR DESCRIPTION

**Jira Issue:** MANU-5491

**Changes proposed in this pull request:**

 + Refactor code to use new popover

**Details of the implementation:**

The new version of the popovers can be used now on the search result,
check kmaps_engine for the changes, now it allows to display the related
assets to the left of the element so it shows properly on the search
results. This requires the use of a SolrUtils object, so it is now instantiated on the flyout partial: _menu
