### PR TITLE
Adds Shapes and Altitudes to Solr documents - MANU-6284

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,6 +67,7 @@ Rails.application.routes.draw do
     get ':id/topics', to: 'features#topics', as: :topics_feature
     get ':feature_id/locations', to: 'locations#index', as: :feature_locations
     get 'gis_resources/:fids.:format', to: 'features#gis_resources', as: :gis_resources
+    get 'geojson_data/:id.:format', to: 'features#geojson_data', as: :geojson_data
     get ':feature_id/by_topic/:id.:format', to: 'topics#feature_descendants'
   end
   resources :topics, only: 'show'

--- a/lib/places_engine/extension/features_controller.rb
+++ b/lib/places_engine/extension/features_controller.rb
@@ -126,6 +126,13 @@ module PlacesEngine
       def characteristics_list
         render :json => CategoryFeature.get_json_data
       end
+
+      def geojson_data
+        f = Feature.get_by_fid(params[:id])
+        shapes = f.shapes.collect(&:as_geojson)
+        response.headers['Content-Type'] = 'application/javascript'
+        render plain: shapes
+      end
       
       def gis_resources
         fids = params[:fids].split(/\D+/)

--- a/lib/places_engine/version.rb
+++ b/lib/places_engine/version.rb
@@ -1,3 +1,3 @@
 module PlacesEngine
-  VERSION = '5.1.4'
+  VERSION = '5.1.5'
 end


### PR DESCRIPTION
**Jira Issue:** MANU-6284

**Changes proposed in this pull request:**

 + Add Shapes (Geometries in GeoJSON) to the Solr document
 + Add Altitues to the Solr document

**Details of the implementation:**

When indexing a feature in Solr, we now include the GeoData in GeoJSON
format and Also the Altitudes.

Both pieces of information (Altitudes and GeoData) are stored as
subdocuments. Solr schema needs to be updated to support field types for
Geometries using the dynamic field `_grptgeom`.