### PR TITLE
Update feature type and Subject relation to use solr - MANU-6392 MANU-6480

### DIFF
--- a/app/assets/javascripts/places_engine/category_features_associations_admin.js
+++ b/app/assets/javascripts/places_engine/category_features_associations_admin.js
@@ -1,0 +1,57 @@
+$(document).ready(function() {
+  var categoryId = $('#category_features_association_js_data').data('featureId');
+  if (categoryId) {
+    categoryId = $('#category_features_association_js_data').data('tree') + "-" + categoryId;
+  } else {
+    categoryId = "";
+  }
+  var featureTypeSolrUtils = kmapsSolrUtils.init({
+    termIndex: $('#category_features_association_js_data').data('termIndex'),
+    assetIndex: $('#category_features_association_js_data').data('assetIndex'),
+    featureId: $('#category_features_association_js_data').data('featureId'),
+    featureId: categoryId,
+    domain: $('#category_features_association_js_data').data('domain'),
+    perspective: $('#category_features_association_js_data').data('perspective'),
+    tree: $('#category_features_association_js_data').data('tree'), //places
+    featuresPath: $('#category_features_association_js_data').data('featuresPath'),
+  });
+  $("#subject_tree_container").kmapsRelationsTree({
+    featureId: categoryId,
+    featuresPath: $('#category_features_association_js_data').data('featuresPath'),
+    termIndex: $('#category_features_association_js_data').data('termIndex'),
+    assetIndex: $('#category_features_association_js_data').data('assetIndex'),
+    perspective: $('#category_features_association_js_data').data('perspective'),
+    tree: $('#category_features_association_js_data').data('tree'), //places
+    domain: $('#category_features_association_js_data').data('domain'), //places
+    extraFields: ["header", "level_gen_i"],
+    descendants: true,
+    directAncestors: false,
+    hideAncestors: false,
+    descendantsFullDetail: false,
+    displayPopup: false,
+    initialScrollToActive: true,
+    solrUtils: featureTypeSolrUtils,
+    nodeMarkerPredicates: [{operation: 'markAll', mark: 'customActionNode'}], //A predicate is: {field:, value:, operation: 'eq', mark: 'nonInteractive'}
+  });
+  if($('#category_features_association_js_data').data('featureId')){
+    $("#subject_name").html("Selected Feature Type: "+ $('#category_features_association_js_data').data('featureTypeName'));
+  }
+  $("#subject_tree_container").on("fancytreeactivate", function(event, data){
+    var level = data.node.getLevel();
+    $("#category_feature_category_id").val(data.node.key.replace($('#category_features_association_js_data').data('domain')+'-',''));
+    $("#subject_name").html("Selected Feature Type: "+ data.node.title);
+    if (level == 1) {
+      if ($("#category_feature_show_parent").prop('checked') == true) {
+        $("#category_feature_show_parent").trigger('click');
+      }
+      $("#category_feature_show_parent").attr("disabled", true);
+      if ($("#category_feature_show_root").prop('checked') == true) {
+        $("#category_feature_show_root").trigger('click');
+      }
+      $("#category_feature_show_root").attr("disabled", true);
+    } else {
+      $("#category_feature_show_parent").attr("disabled", false);
+      $("#category_feature_show_root").attr("disabled", false);
+    }
+  });
+});

--- a/app/assets/javascripts/places_engine/feature_object_types_associations_admin.js
+++ b/app/assets/javascripts/places_engine/feature_object_types_associations_admin.js
@@ -1,0 +1,74 @@
+$(document).ready(function() {
+  var categoryId = "subjects-20";
+  var featureTypeSolrUtils = kmapsSolrUtils.init({
+    termIndex: $('#feature_object_types_association_js_data').data('termIndex'),
+    assetIndex: $('#feature_object_types_association_js_data').data('assetIndex'),
+    featureId: categoryId,
+    domain: $('#feature_object_types_association_js_data').data('domain'),
+    perspective: $('#feature_object_types_association_js_data').data('perspective'),
+    tree: $('#feature_object_types_association_js_data').data('tree'), //places
+    featuresPath: $('#feature_object_types_association_js_data').data('featuresPath'),
+  });
+  $("#subject_tree_container").kmapsRelationsTree({
+    featureId: categoryId,
+    featuresPath: $('#feature_object_types_association_js_data').data('featuresPath'),
+    termIndex: $('#feature_object_types_association_js_data').data('termIndex'),
+    assetIndex: $('#feature_object_types_association_js_data').data('assetIndex'),
+    perspective: $('#feature_object_types_association_js_data').data('perspective'),
+    tree: $('#feature_object_types_association_js_data').data('tree'), //places
+    domain: $('#feature_object_types_association_js_data').data('domain'), //places
+    extraFields: ["header"],
+    descendants: true,
+    directAncestors: true,
+    descendantsFullDetail: false,
+    displayPopup: false,
+    initialScrollToActive: true,
+    solrUtils: featureTypeSolrUtils,
+    nodeMarkerPredicates: [{operation: 'markAll', mark: 'customActionNode'}], //A predicate is: {field:, value:, operation: 'eq', mark: 'nonInteractive'}
+  });
+  function expandTree(tree, ancestors) {
+    if (ancestors) {
+      var ancestor = ancestors.shift();
+      var node = tree.getNodeByKey("subjects-"+ancestor.id);
+      var promise = node.setExpanded();
+      promise.then(function(value){
+        if (ancestors.length >= 1) {
+          expandTree(tree,ancestors);
+        } else {
+          tree.activateKey("subjects-"+ancestor.id);
+        }
+
+      });
+    }
+  }
+  $("#subject_tree_container").on("fancytreeinit", function() {
+    var categoryId = $('#feature_object_types_association_js_data').data('featureId');
+    if (categoryId) {
+      categoryId = $('#feature_object_types_association_js_data').data('tree') + "-" + categoryId;
+      var ancestors = $('#feature_object_types_association_js_data').data('ancestors');
+      var tree = $.ui.fancytree.getTree("#subject_tree_container");
+      expandTree(tree, ancestors);
+    }
+  });
+  if($('#feature_object_types_association_js_data').data('featureId')){
+    $("#subject_name").html("Selected Feature Type: "+ $('#feature_object_types_association_js_data').data('featureTypeName'));
+  }
+  $("#subject_tree_container").on("fancytreeactivate", function(event, data){
+    var level = data.node.getLevel();
+    $("#feature_object_type_category_id").val(data.node.key.replace($('#feature_object_types_association_js_data').data('domain')+'-',''));
+    $("#subject_name").html("Selected Feature Type: "+ data.node.title);
+    if (level == 1) {
+      if ($("#feature_object_type_show_parent").prop('checked') == true) {
+        $("#feature_object_type_show_parent").trigger('click');
+      }
+      $("#feature_object_type_show_parent").attr("disabled", true);
+      if ($("#feature_object_type_show_root").prop('checked') == true) {
+        $("#feature_object_type_show_root").trigger('click');
+      }
+      $("#feature_object_type_show_root").attr("disabled", true);
+    } else {
+      $("#feature_object_type_show_parent").attr("disabled", false);
+      $("#feature_object_type_show_root").attr("disabled", false);
+    }
+  });
+});

--- a/app/controllers/admin/category_features_controller.rb
+++ b/app/controllers/admin/category_features_controller.rb
@@ -4,28 +4,6 @@ class Admin::CategoryFeaturesController < AclController
 
   belongs_to :feature
   
-  def create
-    mca_hash = params[:category_feature]
-    mca_cats = mca_hash[:category_id]
-    @feature = Feature.find(params[:feature_id])
-    if mca_cats.nil?
-      redirect_to admin_feature_url(@feature.fid)
-    elsif mca_cats.size==1
-      mca_hash[:category_id] = mca_cats.first
-      @cf = @feature.category_features.new(mca_hash.permit(:prefix_label, :label, :string_value, :numeric_value, :show_parent, :category_id, :show_root))
-      respond_to do |format|
-        if @cf.save
-          format.html { redirect_to admin_feature_url(@feature.fid) }
-        else
-          format.html { render :action => "new" }
-        end
-      end
-    else
-      mca_cats.each { |c_id| @feature.category_features.create(:category_id => c_id) }
-      redirect_to admin_feature_url(@feature.fid)
-    end
-  end
-  
   def collection
     filter = params[:filter]
     search_results = parent? ? CategoryFeature.contextual_search(filter, parent_object.id) : CategoryFeature.search(filter)

--- a/app/controllers/admin/feature_object_types_controller.rb
+++ b/app/controllers/admin/feature_object_types_controller.rb
@@ -13,29 +13,6 @@ class Admin::FeatureObjectTypesController < AclController
     @parent_object_type = SubjectsIntegration::Feature.find(FeatureObjectType::BRANCH_ID) # feature thesaurus id in topical map builder
   end
   
-  def create
-    mca_hash = feature_object_type_params
-    mca_cats = mca_hash[:category_id]
-    errors = []
-    @feature = Feature.find(params[:feature_id])
-    if mca_cats.nil?
-      redirect_to admin_feature_url(@feature.fid)
-    elsif mca_cats.size==1
-      mca_hash[:category_id] = mca_cats.first
-      @cf = @feature.feature_object_types.new(mca_hash)
-      respond_to do |format|
-        if @cf.save
-          format.html { redirect_to admin_feature_url(@feature.fid) }
-        else
-          format.html { render :action => "new" }
-        end
-      end
-    else
-      mca_cats.each { |c_id| @feature.feature_object_types.create(:category_id => c_id) }
-      redirect_to admin_feature_url(@feature.fid)
-    end
-  end
-
   def collection
     page = params[:page]
     filter = params[:filter]
@@ -58,6 +35,6 @@ class Admin::FeatureObjectTypesController < AclController
   end
 
   def feature_object_type_params
-    params.require(:feature_object_type).permit(:string_value, :numeric_value, :show_parent, :show_root, :label, :prefix_label, category_id: [])
+    params.require(:feature_object_type).permit(:string_value, :numeric_value, :show_parent, :show_root, :label, :prefix_label, :category_id)
   end
 end

--- a/app/models/category_feature.rb
+++ b/app/models/category_feature.rb
@@ -13,6 +13,23 @@ class CategoryFeature < ActiveRecord::Base
 
   validates_presence_of :feature_id
   validates_presence_of :category_id
+  validate :correct_master_parent_selection
+
+  def correct_master_parent_selection
+    category = SubjectsIntegration::Feature.find(self.category_id)
+    # selected show parent and Category is top level
+    if (self.show_parent && category.ancestors.count <= 1)
+      errors.add(:base, 'Show immediate parent is not valid for root nodes.')
+    end
+    # selected show root and Category is top level
+    if (self.show_root && category.ancestors.count <= 1)
+      errors.add(:base, 'Show master subject is not valid for root nodes.')
+    end
+    # selected show parent and root for Category in second level
+    if (self.show_root && self.show_parent && category.ancestors.count == 2 )
+      errors.add(:base, 'Can not select both show immediate parent and show master subject for category in second level, choose one.')
+    end
+  end
 
   after_destroy do |record|
     feature = record.feature

--- a/app/views/admin/category_features/_form_fields.html.erb
+++ b/app/views/admin/category_features/_form_fields.html.erb
@@ -1,16 +1,37 @@
 <%= error_messages_for model_name %>
-<%= category_fields({
-		subject: {display: f_label(object.feature), label: f.label(:feature, Feature.model_name.human.titleize.s) },
-		root: nil,
-		var_name: :category_feature,
-		include_js: false,
-		include_styles: false,
-		selectable: true,
-		single_selection: single_selection,
-		extra_fields: [
-			{field: f.text_field(:string_value, style: 'padding:3px; width: 300px', class: [:text, 'text-full form-control form-text']), label: f.label(:string_value).s},
-			{field: f.text_field(:numeric_value, style: 'padding:3px; width: 300px',class: [:text, 'text-full form-control form-text'] ), label: f.label(:numeric_value).s},
-			{field: f.check_box(:show_parent), label: f.label(:show_parent).s },
-			{field: f.check_box(:show_root), label: f.label(:show_root).s },
-			{field: "#{f.text_field(:label,class: [:text, 'text-full form-text'])} #{f.radio_button(:prefix_label, true)} #{ts('prefix.with', what: '&gt;')} &nbsp;&nbsp;&nbsp;&nbsp;#{f.radio_button(:prefix_label, false)} #{ts('suffix.record', what: 'SPACE')}", label: f.label(:label).s }]
-}) %>
+<%=   f.hidden_field 'category_id' %>
+<div id="subject_name"></div>
+<div class="view-wrap" id="subject_tree_container"></div>
+  <tr><td style='text-align:right;white-space:nowrap'><%= f.label(:text_value)%></td>
+    <td><%= f.text_field(:string_value, style: 'padding:3px; width: 300px', class: [:text, 'text-full form-control form-text'])%></td>
+  </tr>
+  <tr><td style='text-align:right;white-space:nowrap'><%= f.label(:numeric_value)%></td>
+    <td><%= f.text_field(:numeric_value, style: 'padding:3px; width: 300px', class: [:text, 'text-full form-control form-text'])%></td>
+  </tr>
+  <tr><td style='text-align:right;white-space:nowrap'><%= f.label(:show_parent)%></td>
+    <td><%= f.check_box(:show_parent)%></td>
+  </tr>
+  <tr><td style='text-align:right;white-space:nowrap'><%= f.label(:show_root)%></td>
+    <td><%= f.check_box(:show_root)%></td>
+  </tr>
+  <tr><td style='text-align:right;white-space:nowrap'><%= CategoryFeature.human_attribute_name(:label)%></td>
+    <td>
+      <%= f.text_field(:label, class: [:text, 'text-full form-text']) %>
+      <%= f.radio_button(:prefix_label, true)%>
+      <%= ts('prefix.with', what: '&gt;')%>&nbsp;&nbsp;&nbsp;&nbsp;
+      <%= f.radio_button(:prefix_label, false)%>
+      <%= ts('suffix.record', what: 'SPACE')%>
+    </td>
+  </tr>
+<%= content_tag :div, '', id: 'category_features_association_js_data', data: {
+ term_index: Feature.config.url,
+ asset_index: ShantiIntegration::Source.config.url,
+ feature_id: object.category_id,
+ domain: 'subjects',
+ perspective: 'gen',
+ tree: 'subjects',
+ features_path: new_admin_feature_path(parent_id: '%%ID%%'),
+ mandala_path: 'https://mandala.shanti.virginia.edu/%%APP%%/%%ID%%/%%REL%%/nojs',
+ feature_type_name: (object.category.header if !object.category.blank?),
+} %>
+<%= javascript_include_tag 'places_engine/category_features_associations_admin' %>

--- a/app/views/admin/category_features/edit.html.erb
+++ b/app/views/admin/category_features/edit.html.erb
@@ -7,9 +7,14 @@
     <h6><%= Topic.model_name.human.titleize.s %></h6>
   </div>
   <div class="panel-body">
-<%= form_for [:admin, object] do |f| %>
-<%=   category_form_table(form_partial: 'form_fields', footer: "#{link_to ts('cancel.this'), object_path, class: 'btn btn-primary form-submit', id: 'edit-cancel'} | #{globalized_submit_tag 'update.this', class: 'btn btn-primary form-submit'}",
-        locals: { f: f, object: object, single_selection: true }) %>
+<%= form_for [:admin, parent_object, object] do |f| %>
+      <table class='mobj' border='0' cellspacing='0'>
+        <%=   render partial: 'form_fields', locals: {f: f, object: object} %>
+        <tr>
+          <td></td>
+          <td><%= link_to ts('cancel.this'), admin_feature_path(parent_object.fid), class: 'btn btn-primary form-submit', id: 'edit-cancel' %> | <%= globalized_submit_tag 'update.this', class: 'btn btn-primary form-submit' %> </td>
+        </tr>
+      </table>
 <%  end %>
   </div> <!-- END panel-body -->
 </section> <!-- END panel -->

--- a/app/views/admin/category_features/new.html.erb
+++ b/app/views/admin/category_features/new.html.erb
@@ -6,11 +6,14 @@
     <h6><%= Topic.model_name.human.titleize.s %></h6>
   </div>
   <div class="panel-body">
-<%= form_for [:admin, object] do |f| %>
-<%=   hidden_field_tag 'feature_id', object.feature.id %>
-<%=   category_form_table(form_partial: 'form_fields',
-        footer: "#{link_to ts('cancel.this'), collection_path, class: 'btn btn-primary form-submit', id: 'edit-cancel'} | #{globalized_submit_tag 'creat.e.this', class: 'btn btn-primary form-submit'}",
-        locals: { f: f, object: object, single_selection: false }) %>
+<%= form_for [:admin, parent_object, object] do |f| %>
+      <table class='mobj' border='0' cellspacing='0'>
+        <%=   render partial: 'form_fields', locals: {f: f, object: object} %>
+        <tr>
+          <td></td>
+          <td><%= link_to ts('cancel.this'), admin_feature_path(parent_object.fid), class: 'btn btn-primary form-submit', id: 'edit-cancel' %> | <%= globalized_submit_tag 'creat.e.this', class: 'btn btn-primary form-submit' %> </td>
+        </tr>
+      </table>
 <%  end %>
   </div> <!-- END panel-body -->
 </section> <!-- END panel -->

--- a/app/views/admin/feature_object_types/_form_fields.html.erb
+++ b/app/views/admin/feature_object_types/_form_fields.html.erb
@@ -1,17 +1,38 @@
 <%= error_messages_for model_name %>
-<%=	category_fields({
-		subject: {display: f_label(object.feature), label: f.label(:feature, Feature.model_name.human.titleize.s)},
-		root: @parent_object_type,
-		var_name: :feature_object_type,
-		show_dropdown: false,
-		include_js: false,
-		include_styles: false,
-		selectable: true,
-		single_selection: single_selection,
-		extra_fields: [
-			{field: f.text_field(:string_value, style: 'padding:3px; width: 300px', class: [:text, 'text-full form-control form-text']), label: f.label(:text_value).s},
-			{field: f.text_field(:numeric_value, style: 'padding:3px; width: 300px',class: [:text, 'text-full form-control form-text']), label: f.label(:numeric_value).s},
-			{field: f.check_box(:show_parent), label: f.label(:show_parent).s},
-			{field: f.check_box(:show_root), label: f.label(:show_root).s},
-			{field: "#{f.text_field(:label,class: [:text, 'text-full form-text'])} #{f.radio_button(:prefix_label, true)} #{ts('prefix.with', what: '&gt;')} &nbsp;&nbsp;&nbsp;&nbsp;#{f.radio_button(:prefix_label, false)} #{ts('suffix.record', what: 'SPACE')}", label: CategoryFeature.human_attribute_name(:label).s}]
-}) %>
+<%=   f.hidden_field 'category_id' %>
+<div id="subject_name"></div>
+<div class="view-wrap" id="subject_tree_container"></div>
+  <tr><td style='text-align:right;white-space:nowrap'><%= f.label(:text_value)%></td>
+    <td><%= f.text_field(:string_value, style: 'padding:3px; width: 300px', class: [:text, 'text-full form-control form-text'])%></td>
+  </tr>
+  <tr><td style='text-align:right;white-space:nowrap'><%= f.label(:numeric_value)%></td>
+    <td><%= f.text_field(:numeric_value, style: 'padding:3px; width: 300px', class: [:text, 'text-full form-control form-text'])%></td>
+  </tr>
+  <tr><td style='text-align:right;white-space:nowrap'><%= f.label(:show_parent)%></td>
+    <td><%= f.check_box(:show_parent)%></td>
+  </tr>
+  <tr><td style='text-align:right;white-space:nowrap'><%= f.label(:show_root)%></td>
+    <td><%= f.check_box(:show_root)%></td>
+  </tr>
+  <tr><td style='text-align:right;white-space:nowrap'><%= CategoryFeature.human_attribute_name(:label)%></td>
+    <td>
+      <%= f.text_field(:label, class: [:text, 'text-full form-text']) %>
+      <%= f.radio_button(:prefix_label, true)%>
+      <%= ts('prefix.with', what: '&gt;')%>&nbsp;&nbsp;&nbsp;&nbsp;
+      <%= f.radio_button(:prefix_label, false)%>
+      <%= ts('suffix.record', what: 'SPACE')%>
+    </td>
+  </tr>
+<%= content_tag :div, '', id: 'feature_object_types_association_js_data', data: {
+ term_index: Feature.config.url,
+ asset_index: ShantiIntegration::Source.config.url,
+ feature_id: object.category_id,
+ domain: 'subjects',
+ perspective: 'gen',
+ tree: 'subjects',
+ features_path: new_admin_feature_path(parent_id: '%%ID%%'),
+ mandala_path: 'https://mandala.shanti.virginia.edu/%%APP%%/%%ID%%/%%REL%%/nojs',
+ feature_type_name: (object.category.header if !object.category.blank?),
+ ancestors: (object.category.ancestors if !object.category.blank?),
+} %>
+<%= javascript_include_tag 'places_engine/feature_object_types_associations_admin' %>

--- a/app/views/admin/feature_object_types/edit.html.erb
+++ b/app/views/admin/feature_object_types/edit.html.erb
@@ -7,11 +7,14 @@
     <h6><%= FeatureObjectType.model_name.human.titleize.s %></h6>
   </div>
   <div class="panel-body">
-<%= form_for [:admin, object] do |f| %>
-<%=   hidden_field_tag 'feature_id', object.feature.id %>
-<%=	  category_form_table form_partial: 'form_fields',
-        footer: "#{link_to ts('cancel.this'), object_path, class: 'btn btn-primary form-submit', id: 'edit-cancel'} | #{globalized_submit_tag 'update.this', class: 'btn btn-primary form-submit'}",
-        locals: { f: f, object: object, single_selection: true } %>
+<%= form_for [:admin, parent_object, object] do |f| %>
+      <table class='mobj' border='0' cellspacing='0'>
+        <%=   render partial: 'form_fields', locals: {f: f, object: object} %>
+        <tr>
+          <td></td>
+          <td><%= link_to ts('cancel.this'), admin_feature_path(parent_object.fid), class: 'btn btn-primary form-submit', id: 'edit-cancel'%> | <%= globalized_submit_tag 'update.this', class: 'btn btn-primary form-submit' %> </td>
+        </tr>
+      </table>
 <%  end %>
   </div> <!-- END panel-body -->
 </section> <!-- END panel -->

--- a/app/views/admin/feature_object_types/new.html.erb
+++ b/app/views/admin/feature_object_types/new.html.erb
@@ -6,11 +6,14 @@
     <h6><%= FeatureObjectType.model_name.human.titleize.s %></h6>
   </div>
   <div class="panel-body">
-<%= form_for [:admin, object] do |f| %>
-<%=   hidden_field_tag 'feature_id', object.feature.id %>
-<%=	  category_form_table(form_partial: 'form_fields', 
-        footer: "#{link_to ts('cancel.this'), collection_path, class: 'btn btn-primary form-submit', id: 'edit-cancel'} | #{globalized_submit_tag 'creat.e.this', class: 'btn btn-primary form-submit'}",
-        locals: { f: f, object: object, single_selection: false }) %>
+<%= form_for [:admin, parent_object, object] do |f| %>
+      <table class='mobj' border='0' cellspacing='0'>
+        <%=   render partial: 'form_fields', locals: {f: f, object: object} %>
+        <tr>
+          <td></td>
+          <td><%= link_to ts('cancel.this'), admin_feature_path(parent_object.fid), class: 'btn btn-primary form-submit', id: 'edit-cancel' %> | <%= globalized_submit_tag 'creat.e.this', class: 'btn btn-primary form-submit' %> </td>
+        </tr>
+      </table>
 <%  end %>
   </div> <!-- END panel-body -->
 </section> <!-- END panel -->

--- a/lib/places_engine/engine.rb
+++ b/lib/places_engine/engine.rb
@@ -1,8 +1,12 @@
 module PlacesEngine
   class Engine < ::Rails::Engine
     initializer :assets do |config|
-      Rails.application.config.assets.precompile.concat(['places_engine/inset-map.js', 'places_engine/top.js', 'places_engine/THLWMS.js',
-        'places_engine/related-section-initializer.js'])
+      Rails.application.config.assets.precompile.concat(['places_engine/inset-map.js',
+                                                         'places_engine/top.js',
+                                                         'places_engine/THLWMS.js',
+                                                         'places_engine/related-section-initializer.js',
+                                                         'places_engine/feature_object_types_associations_admin.js',
+                                                         'places_engine/category_features_associations_admin.js'])
     end
         
     initializer :loader do |config|

--- a/lib/places_engine/version.rb
+++ b/lib/places_engine/version.rb
@@ -1,3 +1,3 @@
 module PlacesEngine
-  VERSION = '5.1.8'
+  VERSION = '5.1.9'
 end


### PR DESCRIPTION
**Jira Issue:** MANU-6392 MANU-6480

**Changes proposed in this pull request:**

 + Improve Editorial Interface for Feature Type creation
 + Improve Editorial Interface for Subject association creation

**Details of the implementation:**

Adds Validations to JavaScript and Model for Subjects Relations

Improves the Editorial interface for Subjects associations and also
Feature Types association. The Frontend now uses a JavaScript tree that
obtains the information from solr, making it faster. And also adds
validations for common cases for root and second level subjects.

Also added validations on the Model to allow only show root and show
parent when it makes sense.

This commit addresses two JIRA Tickets:

MANU-6392
MANU-6480

