### PR TITLE
Fix GeoJSON code generation on Shapes for Solr indexing - MANU-6596

### DIFF
--- a/app/models/shape.rb
+++ b/app/models/shape.rb
@@ -65,19 +65,7 @@ class Shape < ActiveRecord::Base
     # if done with rgeo:
     # self.geometry.as_text
     # If done directly from db:
-    shape = Shape.select("json_build_object(
-             'type',       'Feature',
-             'id',         gid, -- the GeoJson spec includes an 'id' field, but it is optional
-             'geometry',   ST_AsGeoJSON(ST_ForcePolygonCCW(geometry))::json,
-             'properties', json_build_object(
-                 -- list of fields
-                 'area', area,
-                 'altitude', altitude,
-                 'type', ST_GeometryType(geometry)
-             )
-         )
-    ").find(self.id)
-    shape.nil? ? nil : shape.json_build_object.to_json
+    Shape.select('ST_AsGeoJSON(geometry) as geojson').find(self.id).geojson
   end
   
   def as_ewkt

--- a/lib/places_engine/extension/feature_model.rb
+++ b/lib/places_engine/extension/feature_model.rb
@@ -272,7 +272,7 @@ module PlacesEngine
             {id: "#{self.uid}_shape_#{shape.id}",
              block_child_type: ['places_shape'],
              block_type: ['child'],
-             geometry_grptgeom: shape.as_geojson,
+             geometry_rptgeom: shape.as_geojson,
              geometry_type_s: shape.geo_type_text,
              area_f: shape.area,
              altitude_i: shape.altitude,

--- a/lib/places_engine/version.rb
+++ b/lib/places_engine/version.rb
@@ -1,3 +1,3 @@
 module PlacesEngine
-  VERSION = '5.2.6'
+  VERSION = '5.2.7'
 end


### PR DESCRIPTION
**Jira Issue:** MANU-6596

**Changes proposed in this pull request:**

 + Generate valid GeoJSON representation for Shapes
 + Add the GeoJSON object to Solr on the reindexing action

**Details of the implementation:**

Simplify the `as_geojson` method on Shapes to generate a valid GeoJSON
representation that can be indexed in Solr. Before it was a manually
crafted JSON object from the database. This was replaced by a GeoJSON
representation directly from the databasse.
